### PR TITLE
Issue-4: Use latest tag for localstack image

### DIFF
--- a/local_registry/docker-compose.yml
+++ b/local_registry/docker-compose.yml
@@ -1,16 +1,16 @@
-version: '3.2'
+version: "3.8"
 
 services:
   localstack:
-    image: localstack/localstack:0.10.4
-    container_name: local_aws_s3
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack
     ports:
-      - '4572:4572'
-      - '8055:8080'
+      - "127.0.0.1:4572:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
       - SERVICES=s3
-      - DEBUG=1
-      - DATA_DIR=/tmp/localstack/data
+      - DEBUG=${DEBUG-}
+      - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
-      - './.localstack:/tmp/localstack'
-      - '/var/run/docker.sock:/var/run/docker.sock'
+      - "./.localstack:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
# What Changed
Upgrade to latest localstack.

# Why
This is to fix `Localstack Taking too long to become ready` reported for users using Apple M1.  

